### PR TITLE
JUCX binding implementation.

### DIFF
--- a/java/application/build.gradle
+++ b/java/application/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     implementation project(':disni-binding')
     implementation project(':neutrino-binding')
     implementation project(':jverbs-binding')
+    implementation project(':jucx-binding')
 
     implementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.12.1'
     implementation 'com.google.code.gson:gson:2.8.5'

--- a/java/jucx-binding/build.gradle
+++ b/java/jucx-binding/build.gradle
@@ -1,0 +1,26 @@
+plugins {
+    id 'java-library'
+}
+
+group = 'de.hhu.bsinfo'
+version = getProperty('projectVersion')
+
+compileJava {
+    sourceCompatibility = '8'
+    targetCompatibility = '8'
+    options.encoding = 'UTF-8'
+}
+
+repositories {
+    mavenCentral()
+    maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
+}
+
+dependencies {
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+
+    implementation project(':benchmark')
+
+    implementation 'org.slf4j:slf4j-api:1.7.27'
+    implementation 'org.openucx:jucx:1.8.0'
+}

--- a/java/jucx-binding/src/main/java/de/hhu/bsinfo/observatory/jucx/JucxBenchmark.java
+++ b/java/jucx-binding/src/main/java/de/hhu/bsinfo/observatory/jucx/JucxBenchmark.java
@@ -1,0 +1,241 @@
+package de.hhu.bsinfo.observatory.jucx;
+
+import de.hhu.bsinfo.observatory.benchmark.Benchmark;
+import de.hhu.bsinfo.observatory.benchmark.result.Status;
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Stack;
+import org.openucx.jucx.ucp.UcpConnectionRequest;
+import org.openucx.jucx.ucp.UcpContext;
+import org.openucx.jucx.ucp.UcpEndpoint;
+import org.openucx.jucx.ucp.UcpEndpointParams;
+import org.openucx.jucx.ucp.UcpListener;
+import org.openucx.jucx.ucp.UcpListenerParams;
+import org.openucx.jucx.ucp.UcpMemory;
+import org.openucx.jucx.ucp.UcpParams;
+import org.openucx.jucx.ucp.UcpRemoteKey;
+import org.openucx.jucx.ucp.UcpRequest;
+import org.openucx.jucx.ucp.UcpWorker;
+import org.openucx.jucx.ucp.UcpWorkerParams;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class JucxBenchmark extends Benchmark {
+    private static final Logger LOGGER = LoggerFactory.getLogger(JucxBenchmark.class);
+
+    UcpContext context;
+    UcpWorker worker;
+    UcpListener listener;
+    UcpEndpoint clientToServer, serverToClient;
+    UcpMemory sendMemory, recvMemory;
+    UcpConnectionRequest connectionRequest;
+    UcpRemoteKey remoteKey;
+
+    long remoteAddress;
+    Stack<Closeable> resources = new Stack<>();
+
+    @Override
+    protected Status initialize() {
+        LOGGER.info("Initializing...");
+        UcpParams params = new UcpParams().requestRmaFeature()
+                .requestStreamFeature().requestTagFeature().requestWakeupFeature();
+        context = new UcpContext(params);
+        worker = context.newWorker(new UcpWorkerParams());
+
+        resources.add(context);
+        resources.add(worker);
+        return Status.OK;
+    }
+
+    @Override
+    protected Status serve(InetSocketAddress bindAddress) {
+       InetSocketAddress listenAddr = new InetSocketAddress(bindAddress.getAddress(), bindAddress.getPort() + 12);
+       LOGGER.info("Listener started on {}", listenAddr);
+       UcpListenerParams listenerParams = new UcpListenerParams().setSockAddr(listenAddr)
+                .setConnectionHandler(request -> {
+                   this.connectionRequest = request;
+                });
+        listener = worker.newListener(listenerParams);
+        resources.add(listener);
+
+        while (this.connectionRequest == null) {
+            if (worker.progress() == 0) {
+                worker.waitForEvents();
+            }
+        }
+
+        UcpEndpointParams endpointParams = new UcpEndpointParams().setConnectionRequest(connectionRequest)
+                .setPeerErrorHadnlingMode();
+        serverToClient = worker.newEndpoint(endpointParams);
+
+        // Exchange small message to wire-up connection
+        ByteBuffer buffer = ByteBuffer.allocateDirect(8);
+        worker.progressRequest(worker.recvTaggedNonBlocking(buffer, null));
+        worker.progressRequest(serverToClient.sendTaggedNonBlocking(buffer, null));
+
+        return Status.OK;
+    }
+
+    @Override
+    protected Status connect(InetSocketAddress bindAddress, InetSocketAddress serverAddress) {
+        InetSocketAddress socketAddress = new InetSocketAddress(serverAddress.getAddress(),
+                serverAddress.getPort() + 12);
+        try {
+            Thread.sleep(4000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        LOGGER.info("Connecting to {}", socketAddress);
+        UcpEndpointParams epParams = new UcpEndpointParams().setSocketAddress(socketAddress)
+                .setPeerErrorHadnlingMode();
+        clientToServer = worker.newEndpoint(epParams);
+        // Exchange small message to wire-up connection
+        ByteBuffer buffer = ByteBuffer.allocateDirect(8);
+        worker.progressRequest(clientToServer.sendTaggedNonBlocking(buffer, null));
+        worker.progressRequest(worker.recvTaggedNonBlocking(buffer, null));
+        return Status.OK;
+    }
+
+    private void exchangeMemoryInformation() {
+        UcpEndpoint endpoint = (clientToServer != null) ? clientToServer : serverToClient;
+        ByteBuffer recvMemoryRkey = recvMemory.getRemoteKeyBuffer();
+        ByteBuffer sendMessage = ByteBuffer.allocateDirect(8 + recvMemoryRkey.capacity());
+        ByteBuffer recvMessage = ByteBuffer.allocateDirect(4096);
+
+        sendMessage.putLong(recvMemory.getAddress());
+        sendMessage.put(recvMemoryRkey);
+        sendMessage.clear();
+
+        UcpRequest sendRequest = endpoint.sendStreamNonBlocking(sendMessage, null);
+        UcpRequest recvRequest = endpoint.recvStreamNonBlocking(recvMessage, 0L, null);
+
+        worker.progressRequest(sendRequest);
+        worker.progressRequest(recvRequest);
+
+        remoteAddress = recvMessage.getLong();
+        remoteKey = endpoint.unpackRemoteKey(recvMessage);
+
+        resources.add(endpoint);
+        resources.add(remoteKey);
+    }
+
+    @Override
+    protected Status prepare(int operationSize) {
+        LOGGER.info("Preparing memory regions and exchanging metadata");
+        sendMemory = context.registerMemory(ByteBuffer.allocateDirect(operationSize));
+        recvMemory = context.registerMemory(ByteBuffer.allocateDirect(operationSize));
+
+        resources.add(sendMemory);
+        resources.add(recvMemory);
+
+        exchangeMemoryInformation();
+        return Status.OK;
+    }
+
+    @Override
+    protected Status cleanup() {
+        LOGGER.info("Cleanup ...");
+        while (!resources.isEmpty()) {
+            try {
+                resources.pop().close();
+            } catch (IOException e) {
+                return Status.FILE_ERROR;
+            }
+        }
+        return Status.OK;
+    }
+
+    @Override
+    protected Status fillReceiveQueue() {
+        LOGGER.info("Posting recv request");
+        worker.recvTaggedNonBlocking(recvMemory.getAddress(), recvMemory.getLength(), 0, 0, null);
+        return Status.OK;
+    }
+
+    @Override
+    protected Status sendMultipleMessages(int messageCount) {
+        LOGGER.info("Sending {} messages", messageCount);
+        UcpRequest[] requests = new UcpRequest[messageCount];
+        UcpEndpoint endpoint = (clientToServer != null) ? clientToServer : serverToClient;
+
+        for (int i = 0; i < messageCount; i++) {
+            requests[i] = endpoint.sendTaggedNonBlocking(sendMemory.getAddress(),
+                    sendMemory.getLength(), 0, null);
+        }
+
+        for (int i = 0; i < messageCount; i++) {
+            if (!requests[i].isCompleted()) {
+                worker.progressRequest(requests[i]);
+            }
+        }
+
+        return Status.OK;
+    }
+
+    @Override
+    protected Status receiveMultipleMessages(int messageCount) {
+        LOGGER.info("Receiving {} messages", messageCount);
+        UcpRequest[] requests = new UcpRequest[messageCount];
+
+        for (int i = 0; i < messageCount; i++) {
+            requests[i] = worker.recvTaggedNonBlocking(recvMemory.getAddress(),
+                    recvMemory.getLength(), 0, 0, null);
+        }
+
+        for (int i = 0; i < messageCount; i++) {
+            if (!requests[i].isCompleted()) {
+                worker.progressRequest(requests[i]);
+            }
+        }
+
+        return Status.OK;
+    }
+
+    @Override
+    protected Status performMultipleRdmaOperations(RdmaMode mode, int operationCount) {
+        LOGGER.info("Performing {} RDMA {} operations", operationCount, mode);
+        UcpEndpoint endpoint = (clientToServer != null) ? clientToServer : serverToClient;
+
+        for (int i = 0; i < operationCount; i++) {
+            if (mode == RdmaMode.READ) {
+                endpoint.getNonBlockingImplicit(remoteAddress, remoteKey,
+                        recvMemory.getAddress(), recvMemory.getLength());
+            } else {
+               endpoint.putNonBlockingImplicit(sendMemory.getAddress(), sendMemory.getLength(),
+                        remoteAddress, remoteKey);
+            }
+        }
+
+        worker.progressRequest(endpoint.flushNonBlocking(null));
+
+        return Status.OK;
+    }
+
+    @Override
+    protected Status sendSingleMessage() {
+        sendMultipleMessages(1);
+        return Status.OK;
+    }
+
+    @Override
+    protected Status performSingleRdmaOperation(RdmaMode mode) {
+        return performMultipleRdmaOperations(mode, 1);
+    }
+
+    @Override
+    protected Status performPingPongIterationServer() {
+        sendMultipleMessages(1);
+        receiveMultipleMessages(1);
+        return Status.OK;
+    }
+
+    @Override
+    protected Status performPingPongIterationClient() {
+        receiveMultipleMessages(1);
+        sendMultipleMessages(1);
+        return Status.OK;
+    }
+}

--- a/java/settings.gradle
+++ b/java/settings.gradle
@@ -6,4 +6,5 @@ include 'socket-binding'
 include 'disni-binding'
 include 'neutrino-binding'
 include 'jverbs-binding'
+include 'jucx-binding'
 


### PR DESCRIPTION
JUCX - java bindings over "Unified Communication X" library (https://github.com/openucx/ucx). 

We have a stable release, that is used in [SparkUCX](https://github.com/openucx/sparkucx) project. 

It supports different transports (Infiniband, Roce, Shared memory and can fallback to TCP sockets).

The API is quite simple (you can see by the number of lines in benchmark), but it allows to use different protocols (Tagged send/recv, streaming, RMA operations, atomic, etc.) and hides all low level transport details.

To run JUCX benchmark need to have UCX library installed (the easiest way is to build it) and add it to classpath. 

Let me know if you need help with UCX. Would be curious to compare with other libraries you have.  